### PR TITLE
Remove the requirement for full stops in records.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
 ## Requirements
 - [x] You have completed your website.
 - [x] The website is reachable.
-- [x] You have put a full stop (`.`) at the end of each of the `CNAME`, `MX` and `NS` records. <!-- Example: "google.com." -->
 - [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
 - [x] There is sufficient information at the `owner` field.
 


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] You have put a full stop (`.`) at the end of each of the `CNAME`, `MX` and `NS` records. <!-- Example: "google.com." -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
<!-- Please provide a description below of what you will be using the domain for. -->

## Link to Website
<!-- Please provide a link to your website below. -->
