### PR TITLE
Create latealways.is-not-a.dev.json

### DIFF
--- a/domains/latealways.is-not-a.dev.json
+++ b/domains/latealways.is-not-a.dev.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/domain.schema.json",
+
+  "description": "Project Description",
+
+  "domain": "is-not-a.dev",
+  "subdomain": "latealways",
+
+  "owner": {
+    "repo": "https://github.com/latealways",
+    "email": "latealways@i-am-a.fuchsiax.dev"
+  },
+
+  "record": {
+    "A": ["85.239.250.3"]
+  },
+
+  "proxy": false
+}

--- a/domains/latealways.is-not-a.dev.json
+++ b/domains/latealways.is-not-a.dev.json
@@ -1,13 +1,10 @@
 {
   "$schema": "../schemas/domain.schema.json",
 
-  "description": "Project Description",
-
   "domain": "is-not-a.dev",
   "subdomain": "latealways",
 
   "owner": {
-    "repo": "https://github.com/latealways",
     "email": "latealways@i-am-a.fuchsiax.dev"
   },
 


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
I will be using this domain for my personal projects. A roblox game, a stock trading bot, a personal notifier.

## Link to Website
latealways.is-not-a.dev

It doesn't really have a website the port 80 or 443 is not always in use since this is not a website it is a server.
Alternate domain: latealways.is-a-good.dev

