### PR TITLE
teleportaura.is-cool.dev: change of dns hosting provider

### DIFF
--- a/domains/teleportaura.is-cool.dev.json
+++ b/domains/teleportaura.is-cool.dev.json
@@ -12,7 +12,7 @@
 	},
 
 	"record": {
-		"NS": ["ns1.as207960.net", "ns2.as207960.net"]
+		"NS": ["ns0.1984.is.", "ns1.1984hosting.com", "ns2.1984.is"]
 	},
 
 	"proxy": false


### PR DESCRIPTION
## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
I don't actually want to register a new domain but instead change the name server entry because there were some issues with my old DNS hosting provider. My original application is #283

## Link to Website
https://teleportaura.codeberg.page
