### PR TITLE
Register supacell.is-not-a.dev

### DIFF
--- a/domains/supacell.is-not-a.dev.json
+++ b/domains/supacell.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "supacell",
+
+    "owner": {
+        "email": "samthelegend68@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "idk"
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `supacell.is-not-a.dev` using the [CLI](https://cli.open-domains.net).