### PR TITLE
switch to improvmx (reason: forwardemail is too fucking freemium!)

### DIFF
--- a/domains/aleph.is-local.org.json
+++ b/domains/aleph.is-local.org.json
@@ -11,8 +11,8 @@
 
     "record": {
         "A": ["185.199.111.153"],
-        "MX": ["mx1.forwardemail.net", "mx2.forwardemail.net"],
-        "TXT": ["forward-email=alephdiallo@mail.com"]
+        "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
+        "TXT": ["v=spf1 include:spf.improvmx.com ~all"]
     },
 
     "proxied": false


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
email using improvmx because forwardemail doesn't really let me do that much! 
I know it's a lot of pull requests, I'm sorry for that, but ForwardEmail.net is too limiting. Who pays money to add aliases from their website?!
## Link to Website
http://aleph.is-local.org/ (once again)