### PR TITLE
Register _acme-challenge.edson.is-not-a.dev

### DIFF
--- a/domains/_acme-challenge.edson.is-not-a.dev.json
+++ b/domains/_acme-challenge.edson.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "_acme-challenge.edson",
+
+    "owner": {
+        "email": "edson.bittencourt@outlook.com"
+    },
+
+    "record": {
+        "TXT": ["flfybscxb4bhxhm-pmrfzqwz8enr5izzq4nekmkrysk"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `_acme-challenge.edson.is-not-a.dev` using the [CLI](https://cli.open-domains.net).