### PR TITLE
Register dark.org.is-local.org

### DIFF
--- a/domains/dark.org.is-local.org.json
+++ b/domains/dark.org.is-local.org.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-local.org",
+    "subdomain": "dark.org",
+
+    "owner": {
+        "email": "darkbotzmd@gmail.com"
+    },
+
+    "record": {
+        "A": ["k"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `dark.org.is-local.org` using the [CLI](https://cli.open-domains.net).