### PR TITLE
Register ilitek.is-not-a.dev

### DIFF
--- a/domains/ilitek.is-not-a.dev.json
+++ b/domains/ilitek.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "ilitek",
+
+    "owner": {
+        "email": "ror.yst.one47.8@googlemail.com"
+    },
+
+    "record": {
+        "A": ["146.190.24.230"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `ilitek.is-not-a.dev` using the [CLI](https://cli.open-domains.net).