### PR TITLE
Add GitHub Pages verification TXT record 

### DIFF
--- a/domains/_github-pages-challenge-Jeymen.coding.json
+++ b/domains/_github-pages-challenge-Jeymen.coding.json
@@ -15,7 +15,7 @@
     "record": {
        "A": ["185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153"],
        "MX": ["mx.zoho.eu", "mx2.zoho.eu", "mx3.zoho.eu"],
-       "TXT": ["v=spf1 include:zoho.eu ~all"]
+       "TXT": ["v=spf1 include:zoho.eu ~all", "9619ffcdc7f8882dff012b325e95f0"]
     },
 
     "proxied": false


### PR DESCRIPTION
I have added the TXT record for the GitHub Pages verification.

Question: Should I keep the other records in the GitHub verification file?