### PR TITLE
Register mattia.is-not-a.dev

### DIFF
--- a/domains/mattia.is-not-a.dev.json
+++ b/domains/mattia.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "mattia",
+
+    "owner": {
+        "email": "mikamatto03@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "bumblebee00.github.io"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `mattia.is-not-a.dev` using the [CLI](https://cli.open-domains.net).