### PR TITLE
Update discog.localplayer.dev.json

### DIFF
--- a/domains/discog.localplayer.dev.json
+++ b/domains/discog.localplayer.dev.json
@@ -8,7 +8,9 @@
     },
 
     "record": {
-        "CNAME": "akpi816218.github.io"
+        "CNAME": "akpi816218.github.io",
+        "MX": ["feedback-smtp.us-east-1.amazonses.com"],
+        "TXT": ["v=spf1 include:amazonses.com ~all", "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDpLzHRXLojXqlcCtQruPzxtRlCxuJtWZQJ/HjSql2OsGYgrZP6FkmlyGfEUWXDhzW2fxiS3WCOen0qY2TJ+7Tg85SNNeGzGg8n/ZWHm+dbnxNsz8mGmwRGzR8uKPAOs/reoOfmId5vocbfESQPpPP0wOYFZO+1rg6ugK/TOcBW7QIDAQAB"]
     },
 
     "proxied": false


### PR DESCRIPTION
Add Resend domain verification via TXT records and allow sending via MX records

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
Domain is already in use for Discord bot website, now adding verification for use with emails

## Link to Website
https://discog.localplayer.dev