### PR TITLE
Register thefthelper.is-local.org

### DIFF
--- a/domains/thefthelper.is-local.org.json
+++ b/domains/thefthelper.is-local.org.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-local.org",
+    "subdomain": "thefthelper",
+
+    "owner": {
+        "email": "kibandhonor@gmail.com"
+    },
+
+    "record": {
+        "A": ["127.0.0.1"]
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `thefthelper.is-local.org` using the [CLI](https://cli.open-domains.net).

(This is a Discord bot, not related to stealing at all)