### PR TITLE
Register beyond10dd.is-not-a.dev

### DIFF
--- a/domains/beyond10dd.is-not-a.dev.json
+++ b/domains/beyond10dd.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "beyond10dd",
+
+    "owner": {
+        "email": "nebuchadnezzar0110@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "https://github.com/beyond10dd/beyond10dd.github.io"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `beyond10dd.is-not-a.dev` using the [CLI](https://cli.open-domains.net).