### PR TITLE
Register thehuytong.is-cool.dev

### DIFF
--- a/domains/thehuytong.is-cool.dev.json
+++ b/domains/thehuytong.is-cool.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-cool.dev",
+    "subdomain": "thehuytong",
+
+    "owner": {
+        "email": "tongnguyen.hahuy@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "thehuytong.github.io"
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `thehuytong.is-cool.dev` using the [CLI](https://cli.open-domains.net).