### PR TITLE
Register mtnl-dns-thane.is-local.org

### DIFF
--- a/domains/mtnl-dns-thane.is-local.org.json
+++ b/domains/mtnl-dns-thane.is-local.org.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-local.org",
+    "subdomain": "mtnl-dns-thane",
+
+    "owner": {
+        "email": "niranjan@bitscraft.net"
+    },
+
+    "record": {
+        "A": ["182.58.134.111"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `mtnl-dns-thane.is-local.org` using the [CLI](https://cli.open-domains.net).