### PR TITLE
Register ipcam.is-not-a.dev

### DIFF
--- a/domains/ipcam.is-not-a.dev.json
+++ b/domains/ipcam.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "ipcam",
+
+    "owner": {
+        "email": "jereremy19995@hotmail.sg"
+    },
+
+    "record": {
+        "TXT": [""]
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `ipcam.is-not-a.dev` using the [CLI](https://cli.open-domains.net).