### PR TITLE
Register f0rkn.is-not-a.dev

### DIFF
--- a/domains/f0rkn.is-not-a.dev.json
+++ b/domains/f0rkn.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "f0rkn",
+
+    "owner": {
+        "email": "furkanturkogluu.0@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "f0rkn.com"
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `f0rkn.is-not-a.dev` using the [CLI](https://cli.open-domains.net).