### PR TITLE
Create lighty.is-not-a.dev

### DIFF
--- a/domains/lighty.is-not-a.dev
+++ b/domains/lighty.is-not-a.dev
@@ -1,11 +1,16 @@
 {
-        "owner": {
-           "username": "ssynical",
-           "email": "trapizoids543@gmail.com",
-           "discord": "1108616541739700284"
-        },
+  "description": "my service",
 
-        "record": {
-            "CNAME": "ssynical.github.io"
-        }
-    }
+  "domain": "is-not-a.dev",
+  "subdomain": "lighty",
+
+  "owner": {
+    "email": "trapizoids543@gmail.com"
+  },
+
+  "record": {
+    "CNAME": ["ssynical.github.io"] 
+  },
+
+  "proxied": true
+}

--- a/domains/lighty.is-not-a.dev
+++ b/domains/lighty.is-not-a.dev
@@ -1,0 +1,11 @@
+{
+        "owner": {
+           "username": "ssynical",
+           "email": "trapizoids543@gmail.com",
+           "discord": "1108616541739700284"
+        },
+
+        "record": {
+            "CNAME": "ssynical.github.io"
+        }
+    }


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.

## Description
a home portfolio for my coding passion projects under a subdomain of my github user ssynical in the repo ssynical
also currently being used as lighty.is-a.dev but hosted on github pages

## Link to Website
ssynical.github.io/ssynical (repo)
https://lighty.is-a.dev/
