### PR TITLE
Register httpsiam.is-not-a.dev

### DIFF
--- a/domains/httpsiam.is-not-a.dev.json
+++ b/domains/httpsiam.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "httpsiam",
+
+    "owner": {
+        "email": "s14mshell@gmail.com"
+    },
+
+    "record": {
+        "CNAME": "siamrahman000.github.io"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
Added `httpsiam.is-not-a.dev` using the [CLI](https://cli.open-domains.net).