### PR TITLE
Register maileo.is-not-a.dev

### DIFF
--- a/domains/maileo.is-not-a.dev.json
+++ b/domains/maileo.is-not-a.dev.json
@@ -1,0 +1,14 @@
+{
+    "domain": "is-not-a.dev",
+    "subdomain": "maileo",
+
+    "owner": {
+        "email": "lallen222@student.cccs.edu"
+    },
+
+    "record": {
+        "A": ["8.8.8.8"]
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Added `maileo.is-not-a.dev` using the [CLI](https://cli.open-domains.net).