### PR TITLE
Changed proxied to true

### DIFF
--- a/domains/mail.maragi.is-cool.dev.json
+++ b/domains/mail.maragi.is-cool.dev.json
@@ -10,5 +10,5 @@
         "CNAME": ["webmail.alwaysdata.com"]
     },
 
-    "proxied": false
+    "proxied": true
 }


### PR DESCRIPTION
forgot to set proxied to true for my mail domain.

<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] Your website is not hosting on the following due to SSL issues: `Vercel`, `Netlify`

## Description
Littery just a proxy of my hosts mailcube website to make it look prittier.

## Link to Website
https://webmail.alwaysdata.com > https://mail.maragi.is-cool.dev
