### PR TITLE
Added Nameserver Domain & Glue Record

### DIFF
--- a/domains/manindark.is-local.org.json
+++ b/domains/manindark.is-local.org.json
@@ -1,0 +1,17 @@
+{
+    "description": "Subdomain with Nameserver to test selfhosting with BIND9",
+
+    "domain": "is-local.org",
+    "subdomain": "manindark",
+
+    "owner": {
+        "repo": "https://github.com/ManInDark/OpenDomainsRegister",
+        "email": "manindark.proton.me@proton.me"
+    },
+
+    "record": {
+        "NS": ["ns.manindark.is-local.org"]
+    },
+
+    "proxied": false
+}

--- a/domains/ns.manindark.is-local.org.json
+++ b/domains/ns.manindark.is-local.org.json
@@ -1,0 +1,17 @@
+{
+    "description": "Subdomain with Nameserver to test selfhosting with BIND9 - Glue Record",
+
+    "domain": "is-local.org",
+    "subdomain": "ns.manindark",
+
+    "owner": {
+        "repo": "https://github.com/ManInDark/OpenDomainsRegister",
+        "email": "manindark.proton.me@proton.me"
+    },
+
+    "record": {
+        "AAAA": ["2001:470:70e0:0::5"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.
- [x] There is sufficient information at the `owner` field.
- [x] Your website is not hosting on the following due to SSL issues: `Vercel`, `Netlify`

## Description
As I want to experiment with hosting bind9, this only has a nameserver record. For testing webpages, I'll just put them in the subdomains.

The nameserver should be reachable at `2001:470:70e0::5`, and there is a testing `test.` subdomain, so `dig @2001:470:70e0::5 test.manindark.is-local.org` should return `192.168.1.5`

This is the reason I've added the `ns.manindark.is-local.org` record too, since I needed a glue record.

## Link to Website
There is currently no webpage. If this is a hard requirement, I can add a simple one.