### PR TITLE
Dont proxy setuprank

### DIFF
--- a/domains/auth.setuprank.localplayer.dev.json
+++ b/domains/auth.setuprank.localplayer.dev.json
@@ -8,5 +8,5 @@
     "record": {
         "CNAME": "pro-4729237707907295471.frontendapi.corbado.io"
     },
-    "proxied": true
+    "proxied": false
 }

--- a/domains/setuprank.localplayer.dev.json
+++ b/domains/setuprank.localplayer.dev.json
@@ -8,5 +8,5 @@
     "record": {
         "CNAME": "setuprank.pages.dev"
     },
-    "proxied": true
+    "proxied": false
 }


### PR DESCRIPTION
## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] Your website is not hosting on the following due to SSL issues: `Vercel`, `Netlify`

## Description
I'd like not to proxy my domain through your CF as my auth.* subdomain throws a SSL_ERROR_NO_CYPHER_OVERLAP error when I try to access it through .localplayer.dev domain, but no problems when accessing the CNAME record's value directly. 

## Link to Website
https://setuprank.pages.dev
