### PR TITLE
Add domain vuelib.is-local.org

### DIFF
--- a/domains/vuelib.is-local.org.json
+++ b/domains/vuelib.is-local.org.json
@@ -1,0 +1,17 @@
+{
+    "description": "Document of libraries i write for Vue.JS ommunity",
+
+    "domain": "is-local.org",
+    "subdomain": "vuelib",
+
+    "owner": {
+        "repo": "https://github.com/serariana/register-2",
+        "email": "serariana.com@gmail.com"
+    },
+
+   "record": {
+        "A": ["156.255.1.42"]
+    },
+
+    "proxied": true
+}


### PR DESCRIPTION
Add domain vuelib.is-local.org

## Requirements
- [1] You have completed your website.
- [1] The website is reachable.
- [1] The CNAME record doesn't contain `https://` or `/`.
- [1] There is sufficient information at the `owner` field.
- [1] Your website is not hosting on the following due to SSL issues: `Vercel`, `Netlify`

## Description
The domain will be use for document of some libraries creted for Vue.JS community.

## Link to Website
It's not published yet. but thats like https://ja.vuejs.org/api/application.html#createapp
