### PR TITLE
Update ke46138.is-not-a.dev.json

### DIFF
--- a/domains/ke46138.is-not-a.dev.json
+++ b/domains/ke46138.is-not-a.dev.json
@@ -10,9 +10,7 @@
     },
 
     "record": {
-        "A": ["176.215.57.81"],
-        "MX": ["app.ke46138.is-not-a.dev", "mail.ke46138.is-not-a.dev"],
-        "TXT": ["dkim._domainkey.ke46138.is-not-a.dev = v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD3/KaOfeyLlPY+I8IgTrsop9jT,GL5EtfVKWi7pPI6wmJAJIVH14fvIcMaHpFBY53gD0noZsBSPCNYwqM0VMNH8cnUg,+W2LpNjrYhZxIHWICU5N2jJKfJ7hADxOMVCgm8bs46yUVS3mZqqcorCPqN5djCgq,wLFgGa8y7+AkYVFoTQIDAQAB", "ke46138.is-not-a.dev = v=spf1 mx ~all", "_dmarc.ke46138.is-not-a.dev = v=DMARC1; p=quarantine; adkim=r; aspf=r"]
+        "A": ["213.171.30.54"]
     },
 
     "proxied": false


### PR DESCRIPTION
Changed A record, removed txt and mx records.

<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of Sepetember 4th, 2024)

## Description
<!-- Please provide a description below of what you will be using the domain for. -->
ke46138 page. I will use this subdomain for vnc, http, mail

## Link to Website
<!-- Please provide a link to your website below. -->
http://213.171.30.54