### PR TITLE
fix: Correct the record types able to use proxy

### DIFF
--- a/tests/proxy.test.js
+++ b/tests/proxy.test.js
@@ -2,7 +2,7 @@ const t = require("ava");
 const fs = require("fs-extra");
 const path = require("path");
 
-const requiredRecordsToProxy = ["A", "AAAA", "CNAME"];
+const requiredRecordsToProxy = ["A", "AAAA", "CAA", "CNAME", "MX", "NS", "SPF", "SRV"];
 
 function validateProxiedRecords(t, data, file) {
     if (data.proxied) {


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of Sepetember 4th, 2024)

## Description
<!-- Please provide a description below of what you will be using the domain for. -->

## Link to Website
<!-- Please provide a link to your website below. -->
