### PR TITLE
Fix CNAME record in zone avnss.is-cool.dev

### DIFF
--- a/domains/avnss.is-cool.dev.json
+++ b/domains/avnss.is-cool.dev.json
@@ -7,7 +7,7 @@
 		"email": "avenger_msoft@mail.ru"
 	},
 	"record": {
-		"CNAME": "ss.avnmsoft.xyz"
+		"CNAME": "ss.avnmsoft.com"
 	},
 	"proxied": true
 }


### PR DESCRIPTION
Fix CNAME record in zone avnss.is-cool.dev

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of Sepetember 4th, 2024)