### PR TITLE
Fix anonymous function syntax in forEach calls

### DIFF
--- a/dnsconfig.js
+++ b/dnsconfig.js
@@ -12,7 +12,7 @@ function getDomainsList(filesPath) {
   var result = [];
   var files = glob.apply(null, [filesPath, true, '.json']);
 
-  files.forEach(file => {
+  files.forEach((file) => {
     try {
       const basename = file.split('/').pop();
       const name = basename.split('.')[0];
@@ -45,7 +45,7 @@ function addRecord(domain, record) {
 }
 
 // Process each domain
-domains.forEach(domainEntry => {
+domains.forEach((domainEntry) => {
   const domainData = domainEntry.data;
   let proxyState = proxy.on; // Default to enabled
 
@@ -58,14 +58,14 @@ domains.forEach(domainEntry => {
 
   // Handle A records
   if (domainData.record.A) {
-    domainData.record.A.forEach(ipAddress => {
+    domainData.record.A.forEach((ipAddress) => {
       addRecord(domainData.domain, A(domainData.subdomain, IP(ipAddress), proxyState));
     });
   }
 
   // Handle AAAA records
   if (domainData.record.AAAA) {
-    domainData.record.AAAA.forEach(ipv6 => {
+    domainData.record.AAAA.forEach((ipv6) => {
       addRecord(domainData.domain, AAAA(domainData.subdomain, ipv6, proxyState));
     });
   }
@@ -77,48 +77,48 @@ domains.forEach(domainEntry => {
 
   // Handle MX records
   if (domainData.record.MX) {
-    domainData.record.MX.forEach(mx => {
+    domainData.record.MX.forEach((mx) => {
       addRecord(domainData.domain, MX(domainData.subdomain, 10, mx + "."));
     });
   }
 
   // Handle NS records
   if (domainData.record.NS) {
-    domainData.record.NS.forEach(ns => {
+    domainData.record.NS.forEach((ns) => {
       addRecord(domainData.domain, NS(domainData.subdomain, ns + "."));
     });
   }
 
   // Handle TXT records
   if (domainData.record.TXT) {
-    domainData.record.TXT.forEach(txt => {
+    domainData.record.TXT.forEach((txt) => {
       addRecord(domainData.domain, TXT(domainData.subdomain, txt));
     });
   }
 
   // Handle CAA records
   if (domainData.record.CAA) {
-    domainData.record.CAA.forEach(caaRecord => {
+    domainData.record.CAA.forEach((caaRecord) => {
       addRecord(domainData.domain, CAA(domainData.subdomain, caaRecord.flags, caaRecord.tag, caaRecord.value));
     });
   }
 
   // Handle SRV records
   if (domainData.record.SRV) {
-    domainData.record.SRV.forEach(srvRecord => {
+    domainData.record.SRV.forEach((srvRecord) => {
       addRecord(domainData.domain, SRV(domainData.subdomain, srvRecord.priority, srvRecord.weight, srvRecord.port, srvRecord.target + "."));
     });
   }
 
   // Handle PTR records
   if (domainData.record.PTR) {
-    domainData.record.PTR.forEach(ptr => {
+    domainData.record.PTR.forEach((ptr) => {
       addRecord(domainData.domain, PTR(domainData.subdomain, ptr + "."));
     });
   }
 });
 
 // Commit all DNS records for each domain
-Object.keys(recordsByDomain).forEach(domainName => {
+Object.keys(recordsByDomain).forEach((domainName) => {
   D(domainName, regNone, providerCf, recordsByDomain[domainName]);
 });


### PR DESCRIPTION
Added parens to arguments of anonymous functions in `forEach()` calls

This is a code change, not a DNS registration request/update. Errors suggest there may be more problems beyond these, but the only specifically cited error is currently

```
executing /github/workspace/dnsconfig.js: (anonymous): Line 15:23 Unexpected token > (and 50 more errors)
```

so this should fix at least 11 of 51.