### PR TITLE
Add openmagicblog.is-not-a.dev.json

### DIFF
--- a/domains/openmagicblog.is-not-a.dev.json
+++ b/domains/openmagicblog.is-not-a.dev.json
@@ -1,0 +1,12 @@
+{
+  "description": "草稿小站 - 个人博客",
+  "domain": "is-not-a.dev",
+  "subdomain": "openmagicblog",
+  "owner": {
+    "repo": "https://github.com/3406088084/3406088084.github.io",
+    "email": "3454812161@qq.com"
+  },
+  "record": {
+    "CNAME": "3406088084.github.io"
+  }
+}


### PR DESCRIPTION
## 添加子域名绑定

### 域名信息
- **完整域名**: openmagicblog.is-not-a.dev
- **子域名**: openmagicblog
- **主域名**: is-not-a.dev

### 配置详情
```json
{
  "description": "草稿小站 - 个人博客",
  "domain": "is-not-a.dev",
  "subdomain": "openmagicblog",
  "owner": {
    "repo": "https://github.com/3406088084/3406088084.github.io",
    "email": "3454812161@qq.com"
  },
  "record": {
    "CNAME": "3406088084.github.io"
  }
}