### PR TITLE
Add nextcloud.toly.is-cool.dev, open-webui.toly.is-cool.dev

### DIFF
--- a/domains/nextcloud.toly.is-cool.dev.json
+++ b/domains/nextcloud.toly.is-cool.dev.json
@@ -1,0 +1,12 @@
+{
+  "description": "Self-hosted file sharing and collaboration platform",
+  "domain": "is-cool.dev",
+  "subdomain": "nextcloud.toly",
+  "owner": {
+    "email": "tolyandr@gmail.com"
+  },
+  "record": {
+    "CNAME": "661606e8c73b.sn.mynetname.net"
+  },
+  "proxied": false
+}

--- a/domains/open-webui.toly.is-cool.dev.json
+++ b/domains/open-webui.toly.is-cool.dev.json
@@ -1,0 +1,12 @@
+{
+  "description": "Self-hosted AI platform",
+  "domain": "is-cool.dev",
+  "subdomain": "open-webui.toly",
+  "owner": {
+    "email": "tolyandr@gmail.com"
+  },
+  "record": {
+    "CNAME": "661606e8c73b.sn.mynetname.net"
+  },
+  "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
<!-- Please provide a description below of what you will be using the domain for. -->
I got a home server and a router with dynamic DNS. I would like to serve a bunch web applications for personal use. Dynamic DNS link is just ugly and your service makes a neat url.

https://toly.is-cool.dev and https://immich.toly.is-cool.dev have been registered earlier in https://github.com/open-domains/register/pull/2469. I found that configuration is much easier to deploy apps into the root of domain. And some apps like Immich and Open WebUI even does not support base path in reverse proxy. Therefore I am registering subdomain for each app.

I would like this structure:

- `toly.is-cool.dev`  my personal site (under construction). Temporary serves open-webui 
- `immich.toly.is-cool.dev`  self-hosted photo and video management https://immich.app/
- `nextcloud.toly.is-cool.dev`  self-hosted file sharing and collaboration platform https://nextcloud.com/
- `open-webui.toly.is-cool.dev` self-hosted AI platform https://docs.openwebui.com/




## Link to Website
<!-- Please provide a link to your website below. -->
https://661606e8c73b.sn.mynetname.net