### PR TITLE
Add chimps-place.is-cool.dev (main site) and 4hdto64aev77.chimps-place.is-cool.dev (Google Sites subdomain)

### DIFF
--- a/domains/4hdto64aev77.chimps-place.is-cool.dev.json
+++ b/domains/4hdto64aev77.chimps-place.is-cool.dev.json
@@ -1,5 +1,5 @@
 {
-    "description": "chimps-place.is-cool.dev will be used as the official website for a game on the Meta Quest VR Store. The site is hosted on Google Sites, and the subdomain 4hdto64aev77.chimps-place.is-cool.dev is required to connect the custom domain to Google Sites.",
+    "description": "The subdomain 4hdto64aev77.chimps-place.is-cool.dev is required by Google Sites to connect the custom domain chimps-place.is-cool.dev.",
     "domain": "is-cool.dev",
     "subdomain": "4hdto64aev77.chimps-place",
     "owner": {

--- a/domains/4hdto64aev77.chimps-place.is-cool.dev.json
+++ b/domains/4hdto64aev77.chimps-place.is-cool.dev.json
@@ -1,0 +1,13 @@
+{
+    "description": "4hdto64aev77.chimps-place.is-cool.dev is a domain which is for Google Sites verification of the domain chimps-place.is-cool.dev . chimps-place.is-cool.dev will be used for a game on the meta quest VR store.",
+    "domain": "is-cool.dev",
+    "subdomain": "4hdto64aev77.chimps-place",
+    "owner": {
+        "repo": "https://github.com/phoenicvr/register/",
+        "email": "phoenicinteractive@gmail.com"
+    },
+    "record": {
+        "CNAME": "gv-ez3liwjkagc7xo.dv.googlehosted.com"
+    },
+    "proxied": false
+}

--- a/domains/4hdto64aev77.chimps-place.is-cool.dev.json
+++ b/domains/4hdto64aev77.chimps-place.is-cool.dev.json
@@ -1,5 +1,5 @@
 {
-    "description": "4hdto64aev77.chimps-place.is-cool.dev is a domain which is for Google Sites verification of the domain chimps-place.is-cool.dev . chimps-place.is-cool.dev will be used for a game on the meta quest VR store.",
+    "description": "chimps-place.is-cool.dev will be used as the official website for a game on the Meta Quest VR Store. The site is hosted on Google Sites, and the subdomain 4hdto64aev77.chimps-place.is-cool.dev is required to connect the custom domain to Google Sites.",
     "domain": "is-cool.dev",
     "subdomain": "4hdto64aev77.chimps-place",
     "owner": {

--- a/domains/chimps-place.is-cool.dev.json
+++ b/domains/chimps-place.is-cool.dev.json
@@ -1,0 +1,13 @@
+{
+    "description": "chimps-place.is-cool.dev will be used as the official website for a game on the Meta Quest VR Store. The site is hosted on Google Sites.",
+    "domain": "is-cool.dev",
+    "subdomain": "chimps-place",
+    "owner": {
+        "repo": "https://github.com/phoenicvr/register/",
+        "email": "phoenicinteractive@gmail.com"
+    },
+    "record": {
+        "CNAME": "ghs.googlehosted.com"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
This pull request contains **two domain files**:

1. `chimps-place.is-cool.dev.json`  
   - Defines the main domain `chimps-place.is-cool.dev`, which will be used as the official website for a game on the Meta Quest Store.  
   - The site is hosted on Google Sites, and this domain will serve as the clean, easy-to-remember URL.

2. `4hdto64aev77.chimps-place.is-cool.dev.json`  
   - Defines the Google Sites–required subdomain `4hdto64aev77.chimps-place.is-cool.dev`.  
   - This subdomain is necessary for Google Sites to connect and serve the custom domain `chimps-place.is-cool.dev`.

Together, these entries allow Google Sites hosting to properly serve the website under the custom domain.

## Link to Website
[https://sites.google.com/view/chimps-place/](https://sites.google.com/view/chimps-place/)