### PR TITLE
adding pi subdomain to is cool dev

### DIFF
--- a/domains/pi.is-cool.dev
+++ b/domains/pi.is-cool.dev
@@ -9,10 +9,6 @@
     },
 
     "record": {
-        "A": ["150.136.110.52"],
-        "CAA": [
-            { "flags": 0, "tag": "issue", "value": "letsencrypt.org" },
-        ],
-    },
-    "proxied": false
+        "A": ["150.136.110.52"]
+    }
 }

--- a/domains/pi.is-cool.dev
+++ b/domains/pi.is-cool.dev
@@ -1,0 +1,18 @@
+{
+    "description": "Test Gemini Protocol Server",
+    "domain": "is-cool.dev",
+    "subdomain": "pi",
+
+    "owner": {
+        "repo": "https://github.com/geomlattice/orbit",
+        "email": "logvoid@disroot.org"
+    },
+
+    "record": {
+        "A": ["150.136.110.52"],
+        "CAA": [
+            { "flags": 0, "tag": "issue", "value": "letsencrypt.org" },
+        ],
+    },
+    "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [_] You have completed your website. -> No; I am testing a gemini protocol (between gopher and html)
- [_] The website is reachable. (still working on setting up elixir to run orbit on it)
- [ ] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed. -> Please allow me to test it such that I could work with

```bash
amfora gemini://pi.is-cool.dev
```

I can work on localhost to finish up my site first and try again though, but I am trying to use gemini, not http(s). 

## Description
<!-- Please provide a detailed description below of what you will be using the domain for. -->
I want to test the gemini protocol as an alternative to http. Currently exploring orbit in elixir for this, but if needed I can use a rust server to get something up and running very very soon to get the pull request through, but hopefully in a few days the elixir server runs well on the server in the A record.

## Link to Website
<!-- Please provide a link to your website below. -->
N/A