### PR TITLE
Request subdomain irrg.localplayer.dev for Minecraft server

### DIFF
--- a/domains/irrg.localplayer.dev.json
+++ b/domains/irrg.localplayer.dev.json
@@ -1,0 +1,15 @@
+{
+  "description": "A Minecraft server for IRRG community",
+  "domain": "localplayer.dev",
+  "subdomain": "irrg",
+  
+  "owner": {
+    "email": "siliconr@proton.me"
+  },
+  
+  "record": {
+    "A": ["130.61.111.88"]
+  },
+  
+  "proxied": false
+}


### PR DESCRIPTION
## Requirements
- [x] You have completed your website. <!-- Not applicable - This is a Minecraft server -->
- [x] The website is reachable. <!-- Not applicable - Server is reachable via IP -->
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
This domain will be used to point to a public Minecraft server hosted on Oracle Cloud. The server IP is 130.61.111.88.

## Link to Website
130.61.111.88
Running Forge 1.20.1
