### PR TITLE
Add configuration for sadiq.is-not-a.dev domain

### DIFF
--- a/domains/sadiq.is-not-a.dev.json
+++ b/domains/sadiq.is-not-a.dev.json
@@ -1,0 +1,16 @@
+{
+  "description": "Personal website for Abdul-Latif Sadiq (CLA applied)",
+  "domain": "is-not-a.dev",
+  "subdomain": "sadiq",
+
+  "owner": {
+    "repo": "https://github.com/8adiq",
+    "email": "abdullatifsadiq21@gmail.com"
+  },
+
+  "record": {
+    "CNAME": "sadiq-ten.vercel.app"
+  },
+
+  "proxied": true
+}


### PR DESCRIPTION
This JSON file contains the configuration for the personal website of Abdul-Latif Sadiq, including domain details and owner information.

<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
<!-- Please provide a detailed description below of what you will be using the domain for. -->
Thisis domian will be used for my personal website
## Link to Website
<!-- Please provide a link to your website below. -->
sadiq-ten.vercel.app