### PR TITLE
Add payfopus.is-local.org

### DIFF
--- a/domains/payfopus.is-local.org.json
+++ b/domains/payfopus.is-local.org.json
@@ -1,5 +1,5 @@
 {
-    "description": "Portfolio website for PayFopus — showcasing creative Envato projects, web services, and digital works.",
+    "description": "Portfolio website for PayFopus — showcasing creative Envato projects, web design, and digital services.",
     "domain": "is-local.org",
     "subdomain": "payfopus",
     "owner": {


### PR DESCRIPTION
### Description
Requesting subdomain **payfopus.is-local.org**

### Purpose
Portfolio website for PayFopus — showcasing creative Envato projects, web design, and digital services.

### Domain Information
- Subdomain: `payfopus`
- Domain: `is-local.org`
- Record type: A → 193.190.127.144
- Email: mahmedhleli@gmail.com

Thank you for maintaining Open Domains!