### PR TITLE
Add SPF record for payfopus.is-local.org

### DIFF
--- a/domains/spf.payfopus.is-local.org.json
+++ b/domains/spf.payfopus.is-local.org.json
@@ -1,0 +1,12 @@
+{
+  "domain": "is-local.org",
+  "subdomain": "payfopus",
+  "owner": {
+    "email": "mahmedhleli@gmail.com"
+  },
+  "record": {
+    "TXT": [
+      "v=spf1 a mx ip4:193.190.127.144 ~all"
+    ]
+  }
+}


### PR DESCRIPTION
SPF record for payfopus.is-local.org A website dedicated to digital products 