### PR TITLE
Create mail.payfopus.is-local.org.json

### DIFF
--- a/domains/mail.payfopus.is-local.org.json
+++ b/domains/mail.payfopus.is-local.org.json
@@ -1,0 +1,11 @@
+{
+  "description": "Primary mail server for PayFopus website and services.",
+  "domain": "is-local.org",
+  "subdomain": "mail.payfopus",
+  "owner": {
+    "email": "mahmedhleli@gmail.com"
+  },
+  "record": {
+    "A": ["193.190.127.144"]
+  }
+}


### PR DESCRIPTION
This PR adds an A record for the mail server (mail.payfopus.is-local.org) pointing to 193.190.127.144.
This hostname will be used for SMTP services and PTR/rDNS matching.