### PR TITLE
Create ACME challenge TXT record for is-local.org

### DIFF
--- a/domains/_acme-challenge.payfopus.is-local.org.json
+++ b/domains/_acme-challenge.payfopus.is-local.org.json
@@ -1,0 +1,14 @@
+{
+  "description": "ACME challenge TXT record for SSL verification.",
+  "domain": "is-local.org",
+  "subdomain": "_acme-challenge.payfopus",
+  "owner": {
+    "email": "mahmedhleli@gmail.com"
+  },
+  "record": {
+    "TXT": [
+      "0tLcTdqHyAYX8A7nc9Zu9MZejFC5xoPTBuecBXvlLAo",
+      "LjuxYHUVOkxZudTJxL1BbWHBtcb8j4PfIZ0c_J4-miQ"
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds the _acme-challenge TXT record for SSL verification of payfopus.is-local.org.