### PR TITLE
Add aslabs.is-local.org domain

### DIFF
--- a/domains/aslabs.is-local.org.json
+++ b/domains/aslabs.is-local.org.json
@@ -1,0 +1,20 @@
+{
+    "description": "ASLabs - Local Development Server",
+    "domain": "is-local.org",
+    "subdomain": "aslabs",
+
+    "owner": {
+        "repo": "https://github.com/robertpreshyl/aslabs-webtools",
+        "email": "robert@aslabs.is-local.org"
+    },
+
+    "record": {
+        "A": ["129.80.62.45"],
+        "MX": ["mail.aslabs.is-local.org"],
+        "TXT": [
+            "v=spf1 mx a ip4:129.80.62.45 ~all"
+        ]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
## Domain Registration Request

### Domain Details
- **Domain**: aslabs.is-local.org
- **Points to**: 129.80.62.45
- **Purpose**: ASLabs Local Development Server
- **Repository**: https://github.com/robertpreshyl/aslabs-webtools

### Checklist
- [x] I have read and understood the documentation
- [x] My JSON file follows the correct format
- [x] I own the domain or have permission to use it
- [x] The domain points to the correct IP address
- [x] I am not using this for any illegal purposes

### Additional Information
This subdomain will be used for local development and testing of ASLabs applications.