### PR TITLE
Add aslabs.localplayer.dev domain

### DIFF
--- a/domains/aslabs.localplayer.dev.json
+++ b/domains/aslabs.localplayer.dev.json
@@ -1,0 +1,20 @@
+{
+    "description": "ASLabs - Developer Tools and Testing",
+    "domain": "localplayer.dev",
+    "subdomain": "aslabs",
+
+    "owner": {
+        "repo": "https://github.com/robertpreshyl/aslabs-webtools",
+        "email": "robert@aslabs.localplayer.dev"
+    },
+
+    "record": {
+        "A": ["129.80.62.45"],
+        "MX": ["mail.aslabs.localplayer.dev"],
+        "TXT": [
+            "v=spf1 mx a ip4:129.80.62.45 ~all"
+        ]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
## Domain Registration Request

### Domain Details
- **Domain**: aslabs.localplayer.dev
- **Points to**: 129.80.62.45
- **Purpose**: ASLabs Developer Tools and Testing
- **Repository**: https://github.com/robertpreshyl/aslabs-webtools

### Checklist
- [x] I have read and understood the documentation
- [x] My JSON file follows the correct format
- [x] I own the domain or have permission to use it
- [x] The domain points to the correct IP address
- [x] I am not using this for any illegal purposes

### Additional Information
This subdomain will be used for ASLabs developer tools, testing environments, and web application development.