### PR TITLE
ecpd.is-local.org

### DIFF
--- a/domains/ecpd.is-local.org.json
+++ b/domains/ecpd.is-local.org.json
@@ -1,0 +1,12 @@
+{
+  "description": "ECPD Non-Profit Organization Catch-All Email via Forward Email",
+  "records": [
+    { "type": "MX", "host": "@", "value": "mx1.forwardemail.net", "priority": 10 },
+    { "type": "MX", "host": "@", "value": "mx2.forwardemail.net", "priority": 10 },
+    { 
+      "type": "TXT", 
+      "host": "@", 
+      "value": "forward-email=mr.elhassan2do@gmail.com" 
+    }
+  ]
+}


### PR DESCRIPTION

Adding subdomain ecpd.is-local.org for ECPD, a non-profit organization, to be used with Forward Email.