### PR TITLE
Add stickeroo.is-cool.dev matrix server and future homelab domain entries

### DIFF
--- a/domains/stickeroo.is-cool.dev.json
+++ b/domains/stickeroo.is-cool.dev.json
@@ -11,10 +11,7 @@
         "kyree.ns.cloudflare.com"
     ],
     "record": {
-        "CNAME": { 
-            "matrix": "c4f0ac99-c942-4005-b515-e1d2a66decff.cfargotunnel.com", 
-            "pprlsngx": "c4f0ac99-c942-4005-b515-e1d2a66decff.cfargotunnel.com" 
-        }
+        "CNAME": "c4f0ac99-c942-4005-b515-e1d2a66decff.cfargotunnel.com"
     },
     "proxied": true
 }


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [ ] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [ ] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
Using the domain to setup a matrix communications server via CloudFlare tunnel due to ISP restrictions around port forwarding,
As such that is why the website is not up yet, as I am still learning and in the process of setting it up

Also for experimenting with other services via CloudFlare tunnel

## Link to Website
It is for a matrix server and so doesn't have a website attached, but the server is up and is jist waiting for external setup with the rest of the network
And I am in the process of setting up external access for the other services securely
