### PR TITLE
Modify domain description and DNS record type

### DIFF
--- a/domains/debilai.is-cool.dev.json
+++ b/domains/debilai.is-cool.dev.json
@@ -1,5 +1,5 @@
 {
-    "description": "Minecraft server domain",
+    "description": "Minecraft server domain protected by TCPShield",
     "domain": "is-cool.dev",
     "subdomain": "debilai",
 
@@ -8,7 +8,7 @@
     },
 
     "record": {
-        "A": ["78.60.219.244"]
+        "CNAME": ["d6eb5b8265288643d599f03c7f5c68d4.ipv4.tcpshield.com."]
     },
 
     "proxied": false


### PR DESCRIPTION
Updated the domain description and changed the record type from A to CNAME.

<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [ ] You have completed your website.
- [ ] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
This subdomain will be used primarily for a personal Minecraft server protected via TCPShield.

The DNS record for `debilai.is-cool.dev` has been updated to a CNAME pointing to my TCPShield-protected hostname.

The domain will be used for:
- Allowing players to connect to my Minecraft server using a readable hostname.
- Routing traffic through TCPShield to protect my home server from direct DDoS and bot attacks.

## Link to Website
Currently, this domain is used for Minecraft connectivity via TCPShield