### PR TITLE
Update stickeroo.is-cool.dev Enabling NS after donation

### DIFF
--- a/domains/stickeroo.is-cool.dev.json
+++ b/domains/stickeroo.is-cool.dev.json
@@ -6,12 +6,11 @@
         "repo": "https://github.com/Storm-Trooper5555/open-domains-register",
         "email": "157601224+Storm-Trooper5555@users.noreply.github.com"
     },
-    "NS": [
-        "jen.ns.cloudflare.com",
-        "kyree.ns.cloudflare.com"
-    ],
     "record": {
-        "CNAME": "c4f0ac99-c942-4005-b515-e1d2a66decff.cfargotunnel.com"
+        "NS": [
+            "jen.ns.cloudflare.com",
+            "kyree.ns.cloudflare.com"
+        ]
     },
     "proxied": true
 }


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [ ] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [ ] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
<!-- Please provide a detailed description below of what you will be using the domain for. -->
domain used for homelab, updating and adding the NS after donation

I added a donation, but cannot see the transaction Id
My discord username is storm_trooper53218

![Screenshot_20251119_082908_Brave](https://github.com/user-attachments/assets/eacb32bb-6532-44d1-bdec-d86530a338df)


## Link to Website
<!-- Please provide a link to your website below. -->
