### PR TITLE
Create JSON for wildcard subdomain configuration

### DIFF
--- a/domains/*.vpnpanel.localplayer.dev.json
+++ b/domains/*.vpnpanel.localplayer.dev.json
@@ -1,0 +1,12 @@
+{
+  "description": "Wildcard subdomain for vpnpanel.localplayer.dev — used for dynamic services, API routes, and multi-service access.",
+  "domain": "localplayer.dev",
+  "subdomain": "*.vpnpanel",
+  "owner": {
+    "email": "mahmedhleli@gmail.com"
+  },
+  "record": {
+    "A": ["193.191.169.12"]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Wildcard subdomain for vpnpanel.localplayer.dev — used for dynamic services, API routes, and multi-service access