### PR TITLE
Update CNAME record for ninjastrikers.is-not-a.dev

### DIFF
--- a/domains/ninjastrikers.is-not-a.dev.json
+++ b/domains/ninjastrikers.is-not-a.dev.json
@@ -9,7 +9,7 @@
     },
 
     "record": {
-        "CNAME": "ninjastrikers.net"
+        "CNAME": "ninjastrikers.github.io"
     },
 
     "proxied": false


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
updating CNAME record to ninjastrikers.github.io instead of ninjastrikers.net.

## Link to Website
https://ninjastrikers.github.io/
