### PR TITLE
Add configuration for xmail.is-local.org domain

### DIFF
--- a/domains/xmail.is-local.org.json
+++ b/domains/xmail.is-local.org.json
@@ -1,0 +1,19 @@
+{
+  "description": "Will be used for my custom mail alias",
+  "domain": "is-local.org",
+  "subdomain": "xmail",
+  "owner": {
+    "repo": "https://github.com/tasinone/register",
+    "email": "star.ship430@aleeas.com"
+  },
+  "record": {
+    "MX": [
+      "mx1.forwardemail.net",
+      "mx2.forwardemail.net"
+    ],
+    "TXT": [
+      "forward-email=QXBZVG5vQmo3d19DYlBDRWtLalVmaDlXMkxxU2psaVdYQ3hVWnlYMTNCVmI0QUdjcmRpVFd0eXljSzJWaUE="
+    ]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
Hey, so I am gonna use this domain for my custom email alias for more privacy. My previous request was declined because "Subdomain is too generic and has the potential for abuse." But now I changed it, since I have seen a domain called "tmail.is-local.org" so I think xmail is fine. 
## Link to Website
Since this domain is for my personal alias only, I didn't link to any website. But if it is really required, then I will add one.
