### PR TITLE
Add moonpapers.runs-on.tech

### DIFF
--- a/domains/moonpapers.runs-on.tech.json
+++ b/domains/moonpapers.runs-on.tech.json
@@ -5,7 +5,7 @@
 
     "owner": {
         "repo": "https://github.com/chessmastermind/moon-papers",
-        "email": "your-email@example.com"
+        "email": "allgradeboundaries@gmail.com"
     },
 
     "record": {


### PR DESCRIPTION
Added configuration for moonpapers subdomain with details.

<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
Moon Papers is a minimalist, lightning-fast past paper search tool designed for A-Level students (CIE and Edexcel). My goal is to provide a distraction-free environment for students to find revision materials quickly. The site is hosted via GitHub Pages and is built to be a free, community-focused resource.
## Link to Website
https://chessmastermind.github.io/moon-papers/
