### PR TITLE
Add youthmentalhealthcanada subdomains

### DIFF
--- a/domains/youthmentalhealthcanada.is-local.org.json
+++ b/domains/youthmentalhealthcanada.is-local.org.json
@@ -1,0 +1,16 @@
+{
+    "description": "Youth Mental Health Canada",
+    "domain": "is-local.org",
+    "subdomain": "youthmentalhealthcanada",
+
+    "owner": {
+        "repo": "https://github.com/ymhcanada",
+        "email": "its+opendomains@ymhc.ngo"
+    },
+
+    "record": {
+        "CNAME": "youthmentalhealthcanada.is-local.org.cname.edu-net.ca"
+    },
+
+    "proxied": false
+}

--- a/domains/youthmentalhealthcanada.open-comm.org.json
+++ b/domains/youthmentalhealthcanada.open-comm.org.json
@@ -1,0 +1,16 @@
+{
+    "description": "Youth Mental Health Canada",
+    "domain": "open-comm.org",
+    "subdomain": "youthmentalhealthcanada",
+
+    "owner": {
+        "repo": "https://github.com/ymhcanada",
+        "email": "its+opendomains@ymhc.ngo"
+    },
+
+    "record": {
+        "CNAME": "youthmentalhealthcanada.open-comm.org.cname.edu-net.ca"
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
<!-- Please provide a detailed description below of what you will be using the domain for. -->
Since 2013, we have empowered students, families, educators, community workers, and mental health professionals with the provision of educational resources focused on mental wellness, resilience, strength, and hope. We also provide mental health and wellness education with professional workshops, presentations, and training courses. We are a not-for-profit, charitable community-based organization, offering essential, accessible, and meaningful resources to support the most important role of all.
Government of Canada Charity Registration Number: 771374915-RR0001
The open-comm.org subdomain will be used as backup/fallback/SMTP domain. The is-local.org domain may be purposed for sandbox test environment but I will set up a redirection to the main website.

## Link to Website
<!-- Please provide a link to your website below. -->
https://ymhc.ngo
https://github.com/YMHC-Charitable-Foundation/crisis-resources