### PR TITLE
Added subdomain for minecraft server

### DIFF
--- a/domains/_minecraft._tcp.okurka.is-local.org.json
+++ b/domains/_minecraft._tcp.okurka.is-local.org.json
@@ -1,0 +1,17 @@
+{
+    "description": "Just want to connect to my minecraft server using a domain instead of those long ip adresses",
+    "domain": "is-local.org",
+    "subdomain": "_minecraft._tcp.okurka",
+
+    "owner": {
+        "email": "kontact@weatherscout.zone.id"
+    },
+
+    "record": {
+      "SRV": [
+            { "priority": 1, "weight": 0, "port": 17640, "target": "strong-responded.gl.at.ply.gg" }
+        ]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
I'm not really using it for a website (maybe in a future). I'm currently planning on using it as a custom domain for my minecraft server which is hosted locally through a tunnel. That's why I haven't checked the 'The website is reachable field'. I just want a simpler and easier to remember and share ip adress for my minecraft server.

## Link to Website
As this will be used for a minecraft server, there's no such website to link to