### PR TITLE
Add smashplay.is-cool.dev subdomain for Vercel project

### DIFF
--- a/domains/smashplay.is-cool.dev.json
+++ b/domains/smashplay.is-cool.dev.json
@@ -1,0 +1,20 @@
+{
+  "subdomain": "smashplay",
+  "domain": "is-cool.dev",
+  "owner": "SmashPlay",
+  "description": "SmashPlay gaming platform",
+  "records": [
+    {
+      "type": "A",
+      "name": "@",
+      "value": "216.198.79.1",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "name": "www",
+      "value": "@",
+      "ttl": 3600
+    }
+  ]
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`. 
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
I am requesting the subdomain `smashplay.is-cool.dev` to host my **SmashPlay gaming platform**.  
This is a Vercel-hosted project that includes a collection of HTML5/JS games and a central game hub.  
The subdomain will point to Vercel using the provided A record (`216.198.79.1`).

## Link to Website
https://smashplay.vercel.app