### PR TITLE
Add smashplay.is-cool.dev CNAME pointing to smashplay.vercel.app

### DIFF
--- a/domains/smashplay.is-cool.dev.json
+++ b/domains/smashplay.is-cool.dev.json
@@ -1,20 +1,15 @@
 {
-  "subdomain": "smashplay",
-  "domain": "is-cool.dev",
-  "owner": "SmashPlay",
-  "description": "SmashPlay gaming platform",
-  "records": [
-    {
-      "type": "CNAME",
-      "name": "smashplay",
-      "value": "smashplay.vercel.app",
-      "ttl": 3600
+    "domain": "is-cool.dev",
+    "subdomain": "smashplay",
+    "owner": {
+        "email": "smashplaygames@outlook.com"
     },
-    {
-      "type": "CNAME",
-      "name": "www.smashplay",
-      "value": "smashplay.vercel.app",
-      "ttl": 3600
-    }
-  ]
+    "description": "SmashPlay gaming platform",
+    "record": {
+        "CNAME": [
+            "smashplay.vercel.app",
+            "www.smashplay.vercel.app"
+        ]
+    },
+    "proxied": false
 }


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
This subdomain, `smashplay.is-cool.dev`, will be used for **SmashPlay**, a browser-based gaming platform hosted on Vercel.  
It points directly to the Vercel project (`smashplay.vercel.app`) and also handles the `www` subdomain (`www.smashplay.vercel.app`).  
The subdomain will serve as the official, reachable address for users to access SmashPlay games, providing a stable and reliable connection without SSL/CDN proxying.  

## Link to Website
[https://smashplay.vercel.app](https://smashplay.vercel.app)