### PR TITLE
Add gbarchitect.is-a-fullstack.dev domain

### DIFF
--- a/domains/gbarchitect.is-a-fullstack.dev.json
+++ b/domains/gbarchitect.is-a-fullstack.dev.json
@@ -1,0 +1,16 @@
+{
+  "description": "GBArchitect — Portfolio di architettura",
+  "domain": "is-a-fullstack.dev",
+  "subdomain": "gbarchitect",
+
+  "owner": {
+    "repo": "https://github.com/barifranco-ux/GBArchitect",
+    "email": "barilarogianfranco@gmail.com"
+  },
+
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+
+  "proxied": false
+}


### PR DESCRIPTION
### Description
Requesting the domain gbarchitect.is-a-fullstack.dev for an architecture portfolio hosted on Vercel.

### Type of Change
- [x] New subdomain request

### Checklist
- [x] JSON file placed inside /domains
- [x] Filename matches subdomain.domain.json
- [x] JSON structure matches required format
- [x] All checks pass