### PR TITLE
Add nothing-reminder.localplayer.dev

### DIFF
--- a/domains/nothing-reminder.localplayer.dev.json
+++ b/domains/nothing-reminder.localplayer.dev.json
@@ -1,0 +1,16 @@
+{
+  "description": "Nothing Reminder web application hosted on GitHub Pages",
+  "domain": "localplayer.dev",
+  "subdomain": "nothing-reminder",
+
+  "owner": {
+    "repo": "https://github.com/spydernet3/Nothing-Reminder",
+    "email": "mersalmgblog@gmail.com"
+  },
+
+  "record": {
+    "CNAME": "spydernet3.github.io"
+  },
+
+  "proxied": false
+}


### PR DESCRIPTION
## Requirements

* [x] You have completed your website.
* [x] The website is reachable.
* [x] The CNAME record doesn't contain `https://` or `/`.
* [x] There is sufficient information at the `owner` field.
* [x] There is no NS Records (Enforced as of September 4th, 2024)
* [x] I fully accept and understand the Terms of Service outlined when using this service.
* [x] I understand that if these requirements are not met my pull request will be closed.

## Description

Nothing Reminder is a lightweight web application that allows users to create and manage reminders directly in the browser.
The project is hosted using GitHub Pages and built with HTML, CSS, and JavaScript.
This domain will be used to provide a simple and memorable address for accessing the application online.

## Link to Website

https://spydernet3.github.io/Nothing-Reminder