### PR TITLE
Add wildcard subdomain configuration for matwa.is-cool.dev

### DIFF
--- a/domains/*.matwa.is-cool.dev
+++ b/domains/*.matwa.is-cool.dev
@@ -1,0 +1,11 @@
+{
+  "description": "wildcard subdomains for my personal VPS, it is becoming a hassle to do path based routing for multiple apps. -Matwa",
+  "domain": "is-cool.dev",
+  "subdomain": "*.matwa",
+  "owner": {
+    "email": "mateowatata@gmail.com"
+  },
+  "record": {
+    "A": ["187.124.65.82"]
+  }
+}


### PR DESCRIPTION
Added configuration for wildcard subdomains to simplify routing for multiple applications.


## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
Trying to add new apps to my server is giving me complications with path based routing, so i wanna request wildcard subdomains.

## Link to Website
matwa.is-cool.dev/tabledit
matwa.is-cool.dev

There is also a websocket path and i with the addition of a remote marimo server i'm going insane. 