### PR TITLE
Add proxied field to JSON configuration for *.matwa.is-cool.dev.json

### DIFF
--- a/domains/*.matwa.is-cool.dev.json
+++ b/domains/*.matwa.is-cool.dev.json
@@ -8,4 +8,5 @@
   "record": {
     "A": ["187.124.65.82"]
   }
+  "proxied":  false
 }


### PR DESCRIPTION

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
I am not able to reach my server subdomains  due to something with the TLS certificates, and from what i seen i have to disable the proxying? unsure

## Link to Website
ml.matwa.is-cool.dev
