### PR TITLE
feat: add moux.not-a.dev subdomain

### DIFF
--- a/domains/moux.is-cool.dev.json
+++ b/domains/moux.is-cool.dev.json
@@ -3,7 +3,8 @@
     "domain": "is-cool.dev",
     "subdomain": "moux",
     "owner": {
-        "email": "moux1024@gmail.com"
+        "email": "moux1024@gmail.com",
+        "repo": "https://github.com/moux1024/miniprogram-server"
     },
     "record": {
         "A": [


### PR DESCRIPTION
## Requirements
- [ ] You have completed your website.
- [ ] The website is reachable.
- [x] The CNAME record doesn't contain https:// or /.
- [x] There is sufficient information at the owner field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
 I need the domain to learn relevant knowledge.

## Summary
Added domain registration for moux.not-a.dev

## Details
- **Subdomain**: moux
- **Domain**: not-a.dev  
- **IP**: 103.189.141.143
- **Description**: Service testing