### PR TITLE
Create JSON config for volksgeistt.is-not-a.dev

### DIFF
--- a/domains/volksgeistt.is-not-a.dev.json
+++ b/domains/volksgeistt.is-not-a.dev.json
@@ -1,0 +1,12 @@
+{
+    "description": "domain for a simple portfolio web.",
+    "domain": "is-not-a.dev",
+    "subdomain": "volksgeistt",
+    "owner": {
+        "email": "exrmaniac@gmail.com"
+    },
+    "record": {
+        "CNAME": "volksgeistt-new.netlify.app"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Added JSON configuration for the domain 'is-not-a.dev'.

<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [ x ] You have completed your website.
- [ x ] The website is reachable.
- [ x ] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [ x ] There is sufficient information at the `owner` field.
- [ x ] There is no NS Records (Enforced as of September 4th, 2024)
- [ x ] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [ x ] I understand that if these requirements are not met my pull request will be closed.

## Description
I'll be using it for my personal portfolio web.

## Link to Website
https://volksgeistt-new.netlify.app/