### PR TITLE
Add *.kicdir.is-local.org for KI CDIR CTF

### DIFF
--- a/domains/*.kicdir.is-local.org.json
+++ b/domains/*.kicdir.is-local.org.json
@@ -1,0 +1,15 @@
+{
+    "description": "KI CDIR CTF platform for hands-on cybersecurity challenges and training labs. Subdomain wildcards are used for accessing different backend services.",
+    "domain": "is-local.org",
+    "subdomain": "*.kicdir",
+
+    "owner": {
+        "email": "yogesh.shelke555@gmail.com"
+    },
+
+    "record": {
+        "A": ["35.154.183.179"]
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
<!-- To make our job easier, please spend time to review your application before submitting. -->
<!-- This is REQUIRED. If these fields are not properly filled out, we will automatically close your pull request. -->

## Requirements
- [x] You have completed your website.
- [x] The website is reachable.
- [x] The CNAME record doesn't contain `https://` or `/`.  <!-- This is not required if you are not using a CNAME record. -->
- [x] There is sufficient information at the `owner` field.
- [x] There is no NS Records (Enforced as of September 4th, 2024)
- [x] I fully accept and understand the [Terms of Service](https://github.com/open-domains/register/blob/main/terms.md) outline when using this service.
- [x] I understand that if these requirements are not met my pull request will be closed.

## Description
<!-- Please provide a detailed description below of what you will be using the domain for. -->
KI CDIR CTF platform for hands-on cybersecurity challenges and training labs. Subdomain wildcards are used for accessing different backend services (for e.g., challenges, admin etc.).

## Link to Website
<!-- Please provide a link to your website below. -->
https://35.154.183.179